### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-protos/src/main/java/org/springframework/cloud/stream/app/grpc/support/MessageUtils.java
+++ b/grpc-app-protos/src/main/java/org/springframework/cloud/stream/app/grpc/support/MessageUtils.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-protos/src/main/java/org/springframework/cloud/stream/app/grpc/support/ProtobufMessageBuilder.java
+++ b/grpc-app-protos/src/main/java/org/springframework/cloud/stream/app/grpc/support/ProtobufMessageBuilder.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-protos/src/main/java/org/springframework/cloud/stream/app/grpc/support/RiffMessageBuilder.java
+++ b/grpc-app-protos/src/main/java/org/springframework/cloud/stream/app/grpc/support/RiffMessageBuilder.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-protos/src/main/proto/function.proto
+++ b/grpc-app-protos/src/main/proto/function.proto
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-protos/src/main/proto/processor.proto
+++ b/grpc-app-protos/src/main/proto/processor.proto
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-protos/src/test/java/org/springframework/cloud/stream/app/grpc/support/ProtobufMessageBuilderTests.java
+++ b/grpc-app-protos/src/test/java/org/springframework/cloud/stream/app/grpc/support/ProtobufMessageBuilderTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/AbstractGrpcServer.java
+++ b/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/AbstractGrpcServer.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/AbstractProcessorTest.java
+++ b/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/AbstractProcessorTest.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/ProcessorServer.java
+++ b/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/ProcessorServer.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/ReactorProcessorServer.java
+++ b/grpc-app-test-support/src/main/java/org/springframework/cloud/stream/app/grpc/test/support/ReactorProcessorServer.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-test-support/src/test/java/org/springframework/cloud/stream/app/grpc/test/support/ProcessorTests.java
+++ b/grpc-app-test-support/src/test/java/org/springframework/cloud/stream/app/grpc/test/support/ProcessorTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/grpc-app-test-support/src/test/java/org/springframework/cloud/stream/app/grpc/test/support/ReactorProcessorTests.java
+++ b/grpc-app-test-support/src/test/java/org/springframework/cloud/stream/app/grpc/test/support/ReactorProcessorTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-grpc/src/main/java/org/springframework/cloud/stream/app/grpc/processor/GrpcProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-grpc/src/main/java/org/springframework/cloud/stream/app/grpc/processor/GrpcProcessorConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-grpc/src/main/java/org/springframework/cloud/stream/app/grpc/processor/GrpcProperties.java
+++ b/spring-cloud-starter-stream-processor-grpc/src/main/java/org/springframework/cloud/stream/app/grpc/processor/GrpcProperties.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *  
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *  
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-grpc/src/test/java/org/springframework/cloud/stream/app/grpc/processor/GrpcProcessorTests.java
+++ b/spring-cloud-starter-stream-processor-grpc/src/test/java/org/springframework/cloud/stream/app/grpc/processor/GrpcProcessorTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-grpc/src/test/java/org/springframework/cloud/stream/app/grpc/processor/PingTests.java
+++ b/spring-cloud-starter-stream-processor-grpc/src/test/java/org/springframework/cloud/stream/app/grpc/processor/PingTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 17 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).